### PR TITLE
pinned version of evdev does not support modern python (eg 3.11)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,6 @@ license_file = LICENSE.txt
 packages = find:
 include_package_data = True
 install_requires =
-    evdev~=1.4.0; platform_system=="Linux"
+    evdev>=1.4.0; platform_system=="Linux"
     pywinusb~=0.4.2; platform_system=="Windows"
 python_requires = >=3.6


### PR DESCRIPTION
Python 3.11 is not compatible with the pinned version of evdev in setup.cfg. Module works fine with pinning removed.